### PR TITLE
Upgrade Gradle wrapper to 8.14.3

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip


### PR DESCRIPTION
## Summary
- update the Gradle wrapper configuration to download Gradle 8.14.3 instead of 3.2.1

## Testing
- `./gradlew --version`
- `./gradlew test` *(fails: Could not find any matches for at.bxm.gradleplugins:gradle-svntools-plugin:latest.release)*

------
https://chatgpt.com/codex/tasks/task_i_68a7a72513b483309f3070b134cde425